### PR TITLE
Increase wait time for letting report file generate

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -138,7 +138,7 @@ Resources:
             },
             "wait_using_seconds": {
               "Type": "Wait",
-              "Seconds": 60,
+              "Seconds": 500,
               "Next": "FinalState"
             },
             "FinalState": {


### PR DESCRIPTION
One minute is not enough. Zuora's taking about 3 mins currently
cc @jacobwinch 