### PR TITLE
Bump up dependencies - Snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
-  "com.typesafe.play" %% "play-json" % "2.5.12",
+  "com.typesafe.play" %% "play-json" % "2.6.1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scalacOptions ++= Seq(
 )
 
 lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact)
-val dispatchV = "0.11.4" // change this to appropriate dispatch version
+val dispatchV = "0.11.3" // change this to appropriate dispatch version
 
 scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"
@@ -47,11 +47,12 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
-  "com.typesafe.play" %% "play-json" % "2.6.0",
+  "com.typesafe.play" %% "play-json" % "2.5.12",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "io.netty" % "netty" % "3.10.3.Final"
 )
 
 initialize := {

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scalacOptions ++= Seq(
 )
 
 lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact)
-val dispatchV = "0.11.4" // change this to appropriate dispatch version
+val dispatchV = "0.11.3" // change this to appropriate dispatch version
 
 scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"
@@ -47,9 +47,10 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
-  "com.typesafe.play" %% "play-json" % "2.6.1",
+  "com.typesafe.play" %% "play-json" % "2.5.12",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ libraryDependencies ++= Seq(
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "com.fasterxml.jackson.core" % "jackson-core" % "2.8.8",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "io.netty" % "netty" % "3.10.3.Final"
+  "io.netty" % "netty" % "3.10.3.Final",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 initialize := {

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scalacOptions ++= Seq(
 )
 
 lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact)
-val dispatchV = "0.11.3" // change this to appropriate dispatch version
+val dispatchV = "0.11.4" // change this to appropriate dispatch version
 
 scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
-  "com.typesafe.play" %% "play-json" % "2.5.12",
+  "com.typesafe.play" %% "play-json" % "2.6.0",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scalacOptions ++= Seq(
 )
 
 lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact)
-val dispatchV = "0.11.3" // change this to appropriate dispatch version
+val dispatchV = "0.11.4" // change this to appropriate dispatch version
 
 scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ libraryDependencies ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.8.8",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "io.netty" % "netty" % "3.10.3.Final"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 addSbtPlugin("org.scalaxb" % "sbt-scalaxb" % "1.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 resolvers += Resolver.typesafeRepo("releases")
 resolvers += Resolver.sonatypeRepo("public")


### PR DESCRIPTION
**1. jackson-databind**
https://github.com/guardian/zuora-auto-cancel/pull/65

**2. Denial of Service (DoS) - [CWE-399]**
Remediation: Upgrade to com.typesafe.play:play-json_2.11@2.6.0.

**3. LGPL-3.0 license - MEDIUM SEVERITY**
dispatch-core_2.11@0.11.3
Replace License by Apache if possible

**4. Information Disclosure - [CVE-2015-2156]**
Remediation: Upgrade to net.databinder.dispatch:dispatch-core_2.11@0.11.4.