### PR TITLE
Update jackson-databind (and -core) and add -annotations for snyk fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.5.12",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.8.8",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7", // added for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
   "io.netty" % "netty" % "3.10.3.Final",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )


### PR DESCRIPTION
See https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/

Opening a PR while figuring out how to test/validate these changes.

We found in other projects that bumping `jackson-databind` to 2.9.7 also required an explicit inclusion of `jackson-annotations` at the same level, so I've repeated that here.

Also, I'm unsure whether `jackson-core` needs to be bumped explicitly, but if we can we probably should.

@paulbrown1982 or @jacobwinch are you familiar with this? What do you think?

