### PR TITLE
Updated Jackson library due to Snyk report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,17 +44,17 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "1.0.1" % "compile",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1" % "compile",
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "com.amazonaws" % "aws-java-sdk-kms" % "1.11.477",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-kms" % "1.11.566",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
   "com.typesafe.play" %% "play-json" % "2.6.13",
   "org.scalaj" %% "scalaj-http" % "2.4.1",
   "com.github.melrief" %% "purecsv" % "0.1.1",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.8",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
-  //"com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.0", // This is the version
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.8",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.9",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.9",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.9", // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.9",  // updated for snyk: https://app.snyk.io/org/the-guardian-cuu/project/c8aa728c-1f6a-4ede-900c-dfde0c0af9bf/
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 addSbtPlugin("org.scalaxb" % "sbt-scalaxb" % "1.7.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 resolvers += Resolver.typesafeRepo("releases")
 resolvers += Resolver.sonatypeRepo("public")


### PR DESCRIPTION
Updated Jackson library due to Snyk report. 

Used this opportunity to also upgrade AWS library and SBT versions.

I also removed the sbt-dependency-graph plugin as it wasn't functional, and developers can easily set that up in their local sbt if they want to use it on any project.