### PR TITLE
throw exception if report download was not success-full for better monitoring

### DIFF
--- a/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
@@ -49,8 +49,11 @@ class CreditTransferService(
 
   def processExportFile(exportId: ExportId): Int = {
     val maybeExportCSV = downloadGeneratedExportFile(exportId)
+    if(maybeExportCSV.isEmpty) {
+      // propagate exception to lambda
+      throw new IllegalStateException("Unable to download export of negative invoices to credit")
+    }
     val invoicesWhichNeedCrediting = maybeExportCSV.map(x => invoicesFromReport(ExportFile(x))).getOrElse {
-      logger.error("Unable to download export of negative invoices to credit")
       Set.empty[NegativeInvoiceToTransfer]
     }
     if (invoicesWhichNeedCrediting.isEmpty) {

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
@@ -18,6 +18,7 @@ object ZuoraExportDownloadService extends LazyLogging {
 
     Option(exportId).filter(_.nonEmpty).flatMap { validExportId =>
       val exportResponse = getZuoraExport(validExportId)
+      logger.info(s"getZuoraExport response: $exportResponse")
       val maybeFileId = extractFileId(exportResponse)
       if (maybeFileId.isEmpty) {
         if (exportResponse.contains("Authentication error")) throw new IllegalStateException("ZUORA Authentication error")


### PR DESCRIPTION
## Overview

throw exception if report download was not success-full for better monitoring

## Why

recently we had `117` negative invoices in report but because we could not download the report and logs showed `0` we could not send credit transfer request

logs in PROD have a lot of `Unable to download export of negative invoices to credit` which end up showing `0` invoices to transfer which is incorrect

## Nest step

- send ALARM if `Unable to download export of negative invoices to credit` which will be easy to do once https://github.com/guardian/zuora-creditor/pull/20 will be merged

## Tests

- [x] DEV