### PR TITLE
Add alarm for whenever credit balance adjustment happen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ val jacksonVersion = "2.10.3"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-sns" % "1.11.754",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",
   "com.typesafe.play" %% "play-json" % "2.6.13",
   "ch.qos.logback" % "logback-classic" % "1.2.3",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -13,8 +13,22 @@ Parameters:
     Description: How long the step function should wait (in seconds) for Zuora to generate its Export
     Type: Number
     Default: 500
+  AlarmEmail:
+    Description: AlarmEmail
+    Type: String
+    Default: fulfilment.dev@guardian.co.uk
 
 Resources:
+  CreditBalanceAdjustmentSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub 'alarm-for-whenever-credit-balance-adjustment-happened-${Stage}'
+      Subscription:
+        -
+          Endpoint:
+            Ref: AlarmEmail
+          Protocol: email
+      TopicName: !Sub 'credit-balance-adjustment-happen-${Stage}'
   ZuoraCreditorRole:
     Type: AWS::IAM::Role
     Properties:
@@ -47,6 +61,8 @@ Resources:
                 Action:
                   - kms:Decrypt
                 Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm
+                  - SNS:Publish
+                Resource: !Ref CreditBalanceAdjustmentSNSTopic
   LambdaKMSKey:
     Type: AWS::KMS::Key
     Properties:
@@ -118,6 +134,7 @@ Resources:
           App: zuora-creditor
           Stack: subscriptions
           Stage: !Ref Stage
+          alarms_topic_arn: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:credit-balance-adjustment-happened-${Stage}
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
 
   ZuoraCreditorStepFunctionRole:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -22,13 +22,13 @@ Resources:
   CreditBalanceAdjustmentSNSTopic:
     Type: AWS::SNS::Topic
     Properties:
-      DisplayName: !Sub 'alarm-for-whenever-credit-balance-adjustment-happened-${Stage}'
+      DisplayName: !Sub 'zuora-credit-balance-adjustment-alarms-${Stage}'
       Subscription:
         -
           Endpoint:
             Ref: AlarmEmail
           Protocol: email
-      TopicName: !Sub 'credit-balance-adjustment-happen-${Stage}'
+      TopicName: !Sub 'zuora-credit-balance-adjustment-alarms-${Stage}'
   ZuoraCreditorRole:
     Type: AWS::IAM::Role
     Properties:
@@ -61,6 +61,8 @@ Resources:
                 Action:
                   - kms:Decrypt
                 Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm
+              - Effect: Allow
+                Action:
                   - SNS:Publish
                 Resource: !Ref CreditBalanceAdjustmentSNSTopic
   LambdaKMSKey:
@@ -134,7 +136,7 @@ Resources:
           App: zuora-creditor
           Stack: subscriptions
           Stage: !Ref Stage
-          alarms_topic_arn: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:credit-balance-adjustment-happened-${Stage}
+          alarms_topic_arn: !Ref CreditBalanceAdjustmentSNSTopic
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
 
   ZuoraCreditorStepFunctionRole:

--- a/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
@@ -30,7 +30,7 @@ object Alarmer extends LazyLogging {
            |
            |Alarm Details:
            |- Name: $AdjustmentExecutedAlarmName
-           |- Description: IMPACT: this alarm si to inform us if credit balance adjustments for automated Holiday Credit are happening
+           |- Description: IMPACT: this alarm is to inform us if credit balance adjustments for automated Holiday Credit are happening
            |For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
            |
            |zuora-creditor repository: https://github.com/guardian/zuora-creditor

--- a/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
@@ -30,7 +30,7 @@ object Alarmer extends LazyLogging {
            |
            |Alarm Details:
            |- Name: $AdjustmentExecutedAlarmName
-           |- Description: IMPACT: tjis allram si to inform us if credit balance adjustments for automated Holiday Credit are happening
+           |- Description: IMPACT: this alarm si to inform us if credit balance adjustments for automated Holiday Credit are happening
            |For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
            |
            |zuora-creditor repository: https://github.com/guardian/zuora-creditor

--- a/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
@@ -1,0 +1,44 @@
+package com.gu.zuora.creditor
+
+import com.amazonaws.services.sns.AmazonSNSClient
+import com.amazonaws.services.sns.model.PublishRequest
+import com.typesafe.scalalogging.LazyLogging
+
+object Alarmer extends LazyLogging {
+
+  private val SNS = AmazonSNSClient.builder().build()
+  private val TopicArn = System.getenv("alarms_topic_arn")
+  private val AdjustmentExecutedAlarmName = "zuora-creditor: number of Invoices credited > 0"
+  private val runtimePublishSNS = (messageBody: String) => {
+    SNS.publish(new PublishRequest()
+      .withSubject(s"ALARM: $AdjustmentExecutedAlarmName")
+      .withTargetArn(TopicArn)
+      .withMessage(messageBody)).getMessageId
+  }
+
+  def notifyIfAdjustmentTriggered(adjustmentsReport: AdjustmentsReport, publishToSNS: String => String = runtimePublishSNS): String = {
+    if (adjustmentsReport.negInvoicesWithHolidayCreditAutomated > 0) {
+
+      import adjustmentsReport._
+
+      val messageBody =
+        s"""
+           |You are receiving this email because zuora-creditor executed credit balance adjustments
+           |
+           |Total Number Of Credit Balance Adjustments = $creditBalanceAdjustmentsTotal
+           |Negative invoices With 'Holiday Credit - automated' Credit = $negInvoicesWithHolidayCreditAutomated
+           |
+           |Alarm Details:
+           |- Name: $AdjustmentExecutedAlarmName
+           |- Description: IMPACT: tjis allram si to inform us if credit balance adjustments for automated Holiday Credit are happening
+           |For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
+           |
+           |zuora-creditor repository: https://github.com/guardian/zuora-creditor
+           |""".stripMargin
+
+      logger.info(s"sending notification about numberOfInvoicesCredited > 0 to [$TopicArn]")
+      publishToSNS(messageBody)
+    } else "not-published"
+  }
+
+}

--- a/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 object Alarmer extends LazyLogging {
 
-  private val SNS = AmazonSNSClient.builder().build()
+  private lazy val SNS = AmazonSNSClient.builder().build()
   private val TopicArn = System.getenv("alarms_topic_arn")
   private val AdjustmentExecutedAlarmName = "zuora-creditor: number of Invoices credited > 0"
   private val runtimePublishSNS = (messageBody: String) => {

--- a/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
@@ -66,7 +66,7 @@ class CreditTransferService(
     AdjustmentsReport(totalNumberOfCreditBalanceAdjustments, negativeInvoicesWithAutHolidayCredit)
   }
 
-  def makeCreditAdjustments(invoices: Set[NegativeInvoiceToTransfer]): CreditBalanceAdjustmentIDs = {
+  private def makeCreditAdjustments(invoices: Set[NegativeInvoiceToTransfer]): CreditBalanceAdjustmentIDs = {
     if (invoices.nonEmpty) {
       // Sort by invoice name to help with logging, we're going to credit them in order of their invoice number
       val invoicesToCredit = invoices.toSeq.sortBy(_.invoiceNumber)

--- a/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
@@ -24,7 +24,7 @@ object CreditTransferService extends LazyLogging {
     }.toSet
   }
 
-  def processNegativeInvoicesExportLine(reportLine: NegativeInvoiceFileLine): Either[ErrorMessage, NegativeInvoiceToTransfer] = {
+  private def processNegativeInvoicesExportLine(reportLine: NegativeInvoiceFileLine): Either[ErrorMessage, NegativeInvoiceToTransfer] = {
     // Not HALF_EVEN rounding - we always round to the customer's benefit using UP
     val invoiceBalance = Try(BigDecimal.apply(reportLine.invoiceBalance).setScale(2, UP)).toOption
     val invoiceNumberIsValid = reportLine.invoiceNumber.nonEmpty

--- a/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
@@ -52,19 +52,19 @@ class CreditTransferService(
     maybeExportCSV.foreach { rawCSV =>
       logger.info(s"csv export: $rawCSV")
     }
-    val invoicesWhichNeedCrediting = maybeExportCSV.map(x => processInvoicesFromReport(ExportFile(x))).getOrElse {
+    val invoiceItemsWhichNeedCrediting = maybeExportCSV.map(x => processInvoicesFromReport(ExportFile(x))).getOrElse {
       logger.error("Unable to download export of negative invoices to credit")
       Set.empty[NegativeInvoiceToTransfer]
     }
-    if (invoicesWhichNeedCrediting.isEmpty) {
+    if (invoiceItemsWhichNeedCrediting.isEmpty) {
       logger.warn("No negative invoices require crediting today")
     }
-    val negativeInvoicesWithAutHolidayCredit = invoicesWhichNeedCrediting.
+    val negativeInvoicesWithAutomatedHolidayCredit = invoiceItemsWhichNeedCrediting.
       filter(_.ratePlanName.toLowerCase.contains("automated")).groupBy(_.invoiceNumber).size
-    val makeCreditAdjustmentsResult = makeCreditAdjustments(invoicesWhichNeedCrediting)
+    val makeCreditAdjustmentsResult = makeCreditAdjustments(invoiceItemsWhichNeedCrediting)
     AdjustmentsReport(
       creditBalanceAdjustmentsTotal = makeCreditAdjustmentsResult.size,
-      negativeInvoicesWithAutHolidayCredit
+      negativeInvoicesWithAutomatedHolidayCredit
     )
   }
 

--- a/src/main/scala/com/gu/zuora/creditor/Models.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Models.scala
@@ -9,16 +9,22 @@ object Models {
 
   trait ExportFileLine
 
-  case class NegativeInvoiceFileLine(subscriptionName: String, invoiceNumber: String, invoiceDate: String, invoiceBalance: String) extends ExportFileLine
+  case class NegativeInvoiceFileLine(
+                                      subscriptionName: String,
+                                      ratePlanName: String,
+                                      invoiceNumber: String,
+                                      invoiceDate: String,
+                                      invoiceBalance: String
+                                    ) extends ExportFileLine
 
   case object NegativeInvoiceFileLine {
     val selectForZOQL: ZOQLQueryFragment =
-      "SELECT Subscription.Name, Invoice.InvoiceNumber, Invoice.InvoiceDate, Invoice.Balance " +
+      "SELECT Subscription.Name, RatePlan.Name, Invoice.InvoiceNumber, Invoice.InvoiceDate, Invoice.Balance " +
         "FROM InvoiceItem " +
         "WHERE Invoice.Balance < 0 and Invoice.Status = 'Posted' and Subscription.AutoRenew = 'true'"
   }
 
-  case class NegativeInvoiceToTransfer(invoiceNumber: String, invoiceBalance: BigDecimal, subscriberId: String) {
+  case class NegativeInvoiceToTransfer(invoiceNumber: String, invoiceBalance: BigDecimal, subscriberId: String, ratePlanName: String) {
     val transferrableBalance: BigDecimal = if (invoiceBalance < 0) invoiceBalance * -1 else BigDecimal(0)
   }
 
@@ -38,3 +44,5 @@ object Models {
 object ModelReaders {
   implicit val negativeInvoiceCSVReader: CSVReader[NegativeInvoiceFileLine] = unsafe.CSVReader[NegativeInvoiceFileLine]
 }
+
+final case class AdjustmentsReport(creditBalanceAdjustmentsTotal: Int, negInvoicesWithHolidayCreditAutomated: Int)

--- a/src/main/scala/com/gu/zuora/creditor/Models.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Models.scala
@@ -45,5 +45,4 @@ object ModelReaders {
   implicit val negativeInvoiceCSVReader: CSVReader[NegativeInvoiceFileLine] = unsafe.CSVReader[NegativeInvoiceFileLine]
 }
 
-final case class AdjustmentsReport(creditBalanceAdjustmentsTotal: Int,
-                                   negInvoicesWithHolidayCreditAutomated: Int)
+final case class AdjustmentsReport(creditBalanceAdjustmentsTotal: Int, negInvoicesWithHolidayCreditAutomated: Int)

--- a/src/main/scala/com/gu/zuora/creditor/Models.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Models.scala
@@ -45,4 +45,5 @@ object ModelReaders {
   implicit val negativeInvoiceCSVReader: CSVReader[NegativeInvoiceFileLine] = unsafe.CSVReader[NegativeInvoiceFileLine]
 }
 
-final case class AdjustmentsReport(creditBalanceAdjustmentsTotal: Int, negInvoicesWithHolidayCreditAutomated: Int)
+final case class AdjustmentsReport(creditBalanceAdjustmentsTotal: Int,
+                                   negInvoicesWithHolidayCreditAutomated: Int)

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
@@ -18,6 +18,7 @@ object ZuoraExportDownloadService extends LazyLogging {
 
     Option(exportId).filter(_.nonEmpty).flatMap { validExportId =>
       val exportResponse = getZuoraExport(validExportId)
+      logger.info(s"ZUORA Export status: $exportResponse")
       val maybeFileId = extractFileId(exportResponse)
       if (maybeFileId.isEmpty) {
         if (exportResponse.contains("Authentication error")) throw new IllegalStateException("ZUORA Authentication error")

--- a/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
@@ -1,0 +1,17 @@
+package com.gu.zuora.creditor
+
+import com.gu.zuora.creditor.Alarmer._
+import org.scalatest.{FlatSpec, Matchers}
+
+class AlarmerTest extends FlatSpec with Matchers {
+
+  behavior of "notifyIfAdjustmentTriggered"
+
+  private val publishToSNSStub = (_: String) => "message-id-12314"
+
+  it should "send notification or not if negInvoicesWithHolidayCreditAutomated > 0 " in {
+    notifyIfAdjustmentTriggered(AdjustmentsReport(3, 2), publishToSNSStub) shouldEqual "message-id-12314"
+    notifyIfAdjustmentTriggered(AdjustmentsReport(0, 0), publishToSNSStub) shouldEqual "not-published"
+  }
+
+}

--- a/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.gu.zuora.creditor.CreditTransferService._
 import com.gu.zuora.creditor.ModelReaders._
 import com.gu.zuora.creditor.Models.{ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
-import com.gu.zuora.creditor.Types.CreditBalanceAdjustmentIDs
 import com.gu.zuora.creditor.holidaysuspension.CreateCreditBalanceAdjustment
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
@@ -80,11 +80,11 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
 
   behavior of "processExportFile"
 
-  private val IgnoredValue = "123"
+  private val IgnoredValue = "ignored"
 
   private val downloadEmptyReport = (_: String) => None
 
-  private val downloadReportWith3Invoices = (_: String) => {
+  private val downloadReportWith3ItemsFrom2Invoices = (_: String) => {
     Option(
       """subscriptionName,ratePlanName,invoiceNumber,invoiceDate,invoiceBalance
         |A-S012345,DO NOT USE MANUALLY: Holiday Credit - automated,INV012345,2017-01-01,-2.10
@@ -94,7 +94,7 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
     )
   }
 
-  private val downloadReportWith2Invoices = (_: String) => {
+  private val downloadReportWith2InvoiceItemsFrom2Invoices = (_: String) => {
     Option(
       """subscriptionName,ratePlanName,invoiceNumber,invoiceDate,invoiceBalance
         |A-S012345,DO NOT USE MANUALLY: Holiday Credit - automated,INV012345,2017-01-01,-2.10
@@ -109,13 +109,13 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
 
     val adjustmentsReportActual = new CreditTransferService(
       getAdjustCreditBalanceTestFunc(callCounterOpt = Some(numberOfCalls)),
-      downloadReportWith3Invoices,
+      downloadReportWith3ItemsFrom2Invoices,
       batchSize = 2
     ).processExportFile(IgnoredValue)
 
     adjustmentsReportActual shouldEqual AdjustmentsReport(
       creditBalanceAdjustmentsTotal = 3,
-      negInvoicesWithHolidayCreditAutomated = 2
+      negInvoicesWithHolidayCreditAutomated = 1
     )
     numberOfCalls.intValue() shouldEqual 2
   }
@@ -138,7 +138,7 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
   an[IllegalStateException] should be thrownBy {
     new CreditTransferService(
       getAdjustCreditBalanceTestFunc(failICommandsAtIndexes = Set(0)),
-      downloadReportWith2Invoices
+      downloadReportWith2InvoiceItemsFrom2Invoices
     ).processExportFile(IgnoredValue)
   }
 
@@ -148,7 +148,7 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
     val numberOfCalls = new AtomicInteger
     val adjustmentsReportActual = new CreditTransferService(
       getAdjustCreditBalanceTestFunc(callCounterOpt = Some(numberOfCalls)),
-      downloadReportWith2Invoices
+      downloadReportWith2InvoiceItemsFrom2Invoices
     ).processExportFile(IgnoredValue)
 
     adjustmentsReportActual shouldEqual AdjustmentsReport(

--- a/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
@@ -192,32 +192,6 @@ class CreditTransferServiceTest extends FlatSpec with Matchers {
     )
   }
 
-  it should "makeCreditAdjustments for no invoices" in {
-    val adjustCreditBalanceSuccessStub = getAdjustCreditBalanceTestFunc()
-    val service = new CreditTransferService(
-      adjustCreditBalanceSuccessStub,
-      downloadGeneratedExportFileStub
-    )
-    service.makeCreditAdjustments(Set.empty) shouldEqual Seq.empty
-  }
-
-  it should "makeCreditAdjustments" in {
-    val invoices = Set(
-      NegativeInvoiceToTransfer("INV012345", BigDecimal(-2.1).setScale(2), TestSubscriberId,
-        "DO NOT USE MANUALLY: Holiday Credit - automated"),
-      NegativeInvoiceToTransfer("INV012346", -2.111111, TestSubscriberId, "DO NOT USE MANUALLY: Holiday Credit - automated")
-    )
-
-    val service = new CreditTransferService(
-      getAdjustCreditBalanceTestFunc(),
-      downloadGeneratedExportFileStub
-    )
-    val expected: CreditBalanceAdjustmentIDs = Seq("INV012345", "INV012346")
-
-    val createdAdjustments = service.makeCreditAdjustments(invoices)
-    createdAdjustments shouldEqual expected
-  }
-
   private def createTestCreditBalanceAdjustmentCommand(invoiceId: String) = {
     CreateCreditBalanceAdjustment(
       Amount = 1.2,


### PR DESCRIPTION
## Overview

- Add alarm for whenever credit balance adjustment happen
- refactoring:
-- making `CreditTransferService` more encapsulated such that unit tests will be easier to maintain

## Alarm email:

<img width="993" alt="Screenshot 2020-04-02 at 15 34 23" src="https://user-images.githubusercontent.com/10913420/78261787-92fcb300-74f7-11ea-96ef-478adc085999.png">


## Tests

- [x] DEV

## Adding unit tests now