### PR TITLE
alarm if report download was not success-full

### DIFF
--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
@@ -17,17 +17,17 @@ object ZuoraExportDownloadService extends LazyLogging {
     def downloadExportFile(fileId: FileId) = zuoraRestClient.downloadFile(s"file/$fileId")
 
     val exportResponse = getZuoraExport(exportId)
+    logger.info(s"ZUORA Export response: $exportResponse")
     val reportStatus = extractReportStatus(exportResponse)
     if (reportStatus != "Completed") {
       val errorMessage =
-        s"""attempting to download report which status is '$reportStatus',
+      s"""attempting to download report which status is '$reportStatus',
            |"Consider increasing wait time between the steps in [ZuoraCreditorStepFunction]""".stripMargin
       val alarmMessageId = alarmer.notifyAboutReportDownloadFailure(errorMessage)
       throw new IllegalStateException(
-        s"""$errorMessage
+      s"""$errorMessage
            |alarm was sent to SNS, messageId:$alarmMessageId""".stripMargin)
     }
-    logger.info(s"ZUORA Export response: $exportResponse")
     val fileId = extractFileId(exportResponse)
     val rawCSV = downloadExportFile(fileId)
     // TODO remove dependency from having a  Option[RawCSVText] type here

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
@@ -4,28 +4,35 @@ import com.gu.zuora.creditor.Types.{ExportId, FileId, RawCSVText, SerialisedJson
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.Json.parse
 
-import scala.util.Try
-
 object ZuoraExportDownloadService extends LazyLogging {
 
-  def apply(zuoraRestClient: ZuoraRestClient)(exportId: ExportId): Option[RawCSVText] = {
+  def apply(zuoraRestClient: ZuoraRestClient, alarmer: Alarmer)(exportId: ExportId): Option[RawCSVText] = {
     def getZuoraExport(exportId: ExportId) = zuoraRestClient.makeRestGET(s"object/export/$exportId")
 
     def extractFileId(response: SerialisedJson) =
-      Try((parse(response) \ "FileId").asOpt[String]).toOption.flatten.filter(_.nonEmpty)
+      (parse(response) \ "FileId").as[String]
+
+    def extractReportStatus(response: SerialisedJson) = (parse(response) \ "Status").as[String]
 
     def downloadExportFile(fileId: FileId) = zuoraRestClient.downloadFile(s"file/$fileId")
 
-    Option(exportId).filter(_.nonEmpty).flatMap { validExportId =>
-      val exportResponse = getZuoraExport(validExportId)
-      logger.info(s"ZUORA Export status: $exportResponse")
-      val maybeFileId = extractFileId(exportResponse)
-      if (maybeFileId.isEmpty) {
-        if (exportResponse.contains("Authentication error")) throw new IllegalStateException("ZUORA Authentication error")
-        logger.error(s"No FileId found in Zuora Export: $validExportId. Zuora response: $exportResponse")
-      }
-      maybeFileId.map(downloadExportFile).filter(_.nonEmpty)
+    val exportResponse = getZuoraExport(exportId)
+    val reportStatus = extractReportStatus(exportResponse)
+    if (reportStatus != "Completed") {
+      val errorMessage =
+        s"""attempting to download report which status is '$reportStatus',
+           |"Consider increasing wait time between the steps in [ZuoraCreditorStepFunction]""".stripMargin
+      val alarmMessageId = alarmer.notifyAboutReportDownloadFailure(errorMessage)
+      throw new IllegalStateException(
+        s"""$errorMessage
+           |alarm was sent to SNS, messageId:$alarmMessageId""".stripMargin)
     }
+    logger.info(s"ZUORA Export response: $exportResponse")
+    val fileId = extractFileId(exportResponse)
+    val rawCSV = downloadExportFile(fileId)
+    // TODO remove dependency from having a  Option[RawCSVText] type here
+    // this can be RawCSVText only
+    Some(rawCSV)
   }
 
 

--- a/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
@@ -7,11 +7,19 @@ class AlarmerTest extends FlatSpec with Matchers {
 
   behavior of "notifyIfAdjustmentTriggered"
 
-  private val publishToSNSStub = (_: String) => "message-id-12314"
+  private val TestMessageId = "message-id-12314"
+  private val publishToSNSMock = (_: String, alarmName: String) => s"$alarmName Alarm message-id: $TestMessageId"
 
-  it should "send notification or not if negInvoicesWithHolidayCreditAutomated > 0 " in {
-    notifyIfAdjustmentTriggered(AdjustmentsReport(3, 2), publishToSNSStub) shouldEqual "message-id-12314"
-    notifyIfAdjustmentTriggered(AdjustmentsReport(0, 0), publishToSNSStub) shouldEqual "not-published"
+  private val alarmer = Alarmer(publishToSNSMock)
+
+  it should "send notification with correct alarm name or not if negInvoicesWithHolidayCreditAutomated > 0 " in {
+    alarmer.notifyIfAdjustmentTriggered(AdjustmentsReport(3, 2)) shouldEqual s"$AdjustmentExecutedAlarmName Alarm message-id: $TestMessageId"
+    alarmer.notifyIfAdjustmentTriggered(AdjustmentsReport(0, 0)) shouldEqual "not-published"
   }
 
+  behavior of "notifyAboutReportDownloadFailure"
+
+  it should  "send notification with correct alarm name for Report Download Failure" in {
+    alarmer.notifyAboutReportDownloadFailure("message") shouldEqual s"$ReportDownloadFailureAlarmName Alarm message-id: $TestMessageId"
+  }
 }

--- a/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
@@ -7,8 +7,6 @@ class ZuoraExportDownloadServiceTest extends FlatSpec {
 
   val exportIdCompleted = "foo"
   val exportIdStillProcessing = "foo-processing"
-  val unknownExportId = "bar"
-  val invalidExportId = "baz"
   val fileId = "bim"
   val expectedCSV: RawCSVText =
     """lyric,lyric,lyric,lyric

--- a/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
@@ -5,7 +5,8 @@ import org.scalatest.FlatSpec
 
 class ZuoraExportDownloadServiceTest extends FlatSpec {
 
-  val exportId = "foo"
+  val exportIdCompleted = "foo"
+  val exportIdStillProcessing = "foo-processing"
   val unknownExportId = "bar"
   val invalidExportId = "baz"
   val fileId = "bim"
@@ -24,10 +25,10 @@ class ZuoraExportDownloadServiceTest extends FlatSpec {
     }
 
     override def makeRestGET(path: String): SerialisedJson = {
-      if (path == s"object/export/$exportId") {
-        s"""{"FileId":"$fileId"}"""
-      } else if (path == s"object/export/$unknownExportId") {
-        """{"FileId":"unknown"}"""
+      if (path == s"object/export/$exportIdCompleted") {
+        s"""{"FileId":"$fileId","Status":"Completed"}"""
+      } else if (path == s"object/export/$exportIdStillProcessing") {
+        s"""{"FileId":"$fileId","Status":"Processing"}"""
       } else {
         """{"invalid":"invalid"}"""
       }
@@ -36,20 +37,28 @@ class ZuoraExportDownloadServiceTest extends FlatSpec {
     override def makeRestPOST(path: String)(commandJSON: SerialisedJson): SerialisedJson = ???
   }
 
+  private val TestSnsMessageId = "id123"
+
+  private val alarmerStub = Alarmer(publishToSNS = (_: String, _: String) => TestSnsMessageId)
+
+  private val downloadGeneratedExportFile = ZuoraExportDownloadService.apply(zuoraRestClient, alarmerStub) _
+
   behavior of "ZuoraExportDownloaderTest"
 
   it should "downloadGeneratedExportFile" in {
-    val downloadGeneratedExportFile = ZuoraExportDownloadService.apply(zuoraRestClient) _
-    val csvFile = downloadGeneratedExportFile(exportId)
+    val csvFile = downloadGeneratedExportFile(exportIdCompleted)
     assert(csvFile.contains(expectedCSV))
-    val unknownCsvFile = downloadGeneratedExportFile(unknownExportId)
-    assert(unknownCsvFile.isEmpty)
-    val invalidCsvFile1 = downloadGeneratedExportFile(invalidExportId)
-    assert(invalidCsvFile1.isEmpty)
-    val invalidCsvFile2 = downloadGeneratedExportFile(null)
-    assert(invalidCsvFile2.isEmpty)
-    val invalidCsvFile3 = downloadGeneratedExportFile("")
-    assert(invalidCsvFile3.isEmpty)
+  }
+
+  it should "downloadGeneratedExportFile throws exception and sends alarm if status is not Completed" in {
+    val thrown = intercept[IllegalStateException] {
+      downloadGeneratedExportFile(exportIdStillProcessing)
+    }
+
+    assert(thrown.getMessage ==
+      s"""attempting to download report which status is 'Processing',
+         |"Consider increasing wait time between the steps in [ZuoraCreditorStepFunction]
+         |alarm was sent to SNS, messageId:$TestSnsMessageId""".stripMargin)
   }
 
 }


### PR DESCRIPTION
## Overview
- adding alarm in situation if we are attempting to download report that is still in processing
- deleting silent failures from ZuoraExportDownloadService

## Why

- recently i noticed that `ZuoraCreditorStepFunction` was silently failing every day because it tried to download the report that was not ready

- that solution will allow us to monitor if the WaitTime `between generate` report and `download report` is enough

## Tests

- [x] DEV