### PR TITLE
Remove dependency on Bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ val jacksonVersion = "2.10.3"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-java-sdk-sns" % "1.11.754",
-  "com.gu" %% "simple-configuration-ssm" % "1.4.1",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.5",
   "com.typesafe.play" %% "play-json" % "2.6.13",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,6 @@ initialize := {
   assert(sys.props("java.specification.version") == "1.8", "Java 8 is required for this project.")
 }
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", xs@_*) => MergeStrategy.discard
   case x => MergeStrategy.first


### PR DESCRIPTION
Removed reference to Bintray and a dependency that came from Bintray.

Tested this by moving local caches and then running `assembly` to see where it fails.
