### PR TITLE
Add cloudformation template to Riffraff artefacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Creditor"
+riffRaffArtifactResources += (file("cloudformation.yaml"), "cfn/cfn.yaml")
 
 addCommandAlias("dist", ";riffRaffArtifact")
 


### PR DESCRIPTION
## What does this change?
During the migration of lambda Java runtimes we discovered that changes to the cloudformation template for this project weren't being recognised on deploy because the cloudformation template isn't included in the Riffraff deployment recipe.

So this change includes the cloudformation template for the project stack as an artefact that Riffraff can deploy.

## How to test

1. At the point where the Teamcity build exports artefacts to S3, it should include the cloudformation template file as well as the other artefacts.  
2. In the deployment S3 bucket, the file should appear under the build folder at cfn/cfn.yaml.
