### PR TITLE
Include cloudformation stack update in Riffraff deployments

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,6 +3,14 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+  cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml
+      cloudFormationStackName: zuora-creditor
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      createStackIfAbsent: false  
   zuora-creditor:
     type: aws-lambda
     parameters:
@@ -11,3 +19,4 @@ deployments:
       prefixStack: false
       functionNames:
       - zuora-creditor-
+      


### PR DESCRIPTION
## What does this change?
Following on from #31, this uses the new artefact in the Riffraff deployment process.

## How to test
1. Run a Riffraff deploy.
It should update any changes to the stack from the cloudformation template as well as redeploying the jar.
