### PR TITLE
Make jar deploy depend on cfn deploy

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,4 +19,4 @@ deployments:
       prefixStack: false
       functionNames:
       - zuora-creditor-
-      
+    dependencies: [cfn]


### PR DESCRIPTION
Currently, cloudformation and jar will deploy in parallel whereas we want the cloudformation to deploy first.