### PR TITLE
Upgrade lambda to Java 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,18 +48,15 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
-initialize := {
-  val _ = initialize.value
-  assert(
-    sys.props("java.specification.version") == "1.8",
-    "Java 8 is required for this project."
-  )
-}
-
 assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", _ @ _*) => MergeStrategy.discard
-  case _                             => MergeStrategy.first
+  case PathList("META-INF", "MANIFEST.MF")                  => MergeStrategy.discard
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
+  case PathList("codegen-resources", _)                     => MergeStrategy.discard
+  case PathList("module-info.class")                        => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -77,7 +77,7 @@ Resources:
       Handler: com.gu.zuora.creditor.Lambda::handleRequest
       MemorySize: 512
       Role: !GetAtt ZuoraCreditorRole.Arn
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 60
       Environment:
         Variables:


### PR DESCRIPTION
Upgrading from Java 8 to Java 11 seems to be fine except that the AWS Java SDK could no longer find the default HTTP client to use.  This resulted in the runtime exception:
`software.amazon.awssdk.core.exception.SdkClientException: Unable to load an HTTP implementation from any provider in the chain. You must declare a dependency on an appropriate HTTP implementation or pass in an SdkHttpClient explicitly to the client builder.`

I don't know why this should happen as a result of upgrading Java unless the SDK was previously finding a default HTTP client in the Java package.

The solution to this was to ensure that the [relevant services file](https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/apache-client/src/main/resources/META-INF/services/software.amazon.awssdk.http.SdkHttpService) was included in the assembled jar by reducing the number of discarded files during the jar assembly.

Tested in Code.

See https://github.com/guardian/zuora-creditor/pull/30#issuecomment-1163300127
