### PR TITLE
Better casing for Alarmer variables

### DIFF
--- a/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Alarmer.scala
@@ -2,29 +2,29 @@ package com.gu.zuora.creditor
 
 import com.amazonaws.services.sns.AmazonSNSClient
 import com.amazonaws.services.sns.model.PublishRequest
-import com.gu.zuora.creditor.Alarmer.{AdjustmentExecutedAlarmName, ReportDownloadFailureAlarmName, TopicArn, logger}
+import com.gu.zuora.creditor.Alarmer.{adjustmentExecutedAlarmName, reportDownloadFailureAlarmName, topicArn, logger}
 import com.typesafe.scalalogging.LazyLogging
 
 object Alarmer extends LazyLogging {
 
-  private lazy val SNS = AmazonSNSClient.builder().build()
-  private val TopicArn = System.getenv("alarms_topic_arn")
+  private lazy val snsClient = AmazonSNSClient.builder().build()
+  private val topicArn = System.getenv("alarms_topic_arn")
 
-  private val Stage = System.getenv().getOrDefault("Stage", "DEV")
+  private val stage = System.getenv().getOrDefault("Stage", "DEV")
 
-  val RuntimePublishSNS: (String, String) => String = (messageBody: String, alarmName: String) => {
-    val msgID = SNS.publish(new PublishRequest()
+  val runtimePublishSNS: (String, String) => String = (messageBody: String, alarmName: String) => {
+    val msgID = snsClient.publish(new PublishRequest()
       .withSubject(s"ALARM: $alarmName")
-      .withTargetArn(TopicArn)
+      .withTargetArn(topicArn)
       .withMessage(messageBody)).getMessageId
     s"$alarmName Alarm message-id: $msgID"
   }
-  val AdjustmentExecutedAlarmName = s"zuora-creditor $Stage: number of Invoices credited > 0"
-  val ReportDownloadFailureAlarmName = s"zuora-creditor $Stage: Unable to download export of negative invoices to credit"
+  val adjustmentExecutedAlarmName = s"zuora-creditor $stage: number of Invoices credited > 0"
+  val reportDownloadFailureAlarmName = s"zuora-creditor $stage: Unable to download export of negative invoices to credit"
 
   def apply(publishToSNS: (String, String) => String): Alarmer = new Alarmer(publishToSNS)
 
-  def apply: Alarmer = new Alarmer(RuntimePublishSNS)
+  def apply: Alarmer = new Alarmer(runtimePublishSNS)
 }
 
 class Alarmer(publishToSNS: (String, String) => String) extends LazyLogging {
@@ -41,15 +41,15 @@ class Alarmer(publishToSNS: (String, String) => String) extends LazyLogging {
            |Negative invoices With 'Holiday Credit - automated' Credit = $negInvoicesWithHolidayCreditAutomated
            |
            |Alarm Details:
-           |- Name: $AdjustmentExecutedAlarmName
+           |- Name: $adjustmentExecutedAlarmName
            |- Description: IMPACT: this alarm is to inform us if credit balance adjustments for automated Holiday Credit are happening
            |For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
            |
            |zuora-creditor repository: https://github.com/guardian/zuora-creditor
            |""".stripMargin
 
-      logger.info(s"sending notification about numberOfInvoicesCredited > 0 to [$TopicArn]")
-      publishToSNS(messageBody, AdjustmentExecutedAlarmName)
+      logger.info(s"sending notification about numberOfInvoicesCredited > 0 to [$topicArn]")
+      publishToSNS(messageBody, adjustmentExecutedAlarmName)
     } else "not-published"
   }
 
@@ -62,7 +62,7 @@ class Alarmer(publishToSNS: (String, String) => String) extends LazyLogging {
          |$errorMessage
          |
          |Alarm Details:
-         |- Name: $ReportDownloadFailureAlarmName
+         |- Name: $reportDownloadFailureAlarmName
          |- Description: IMPACT: if this goes unaddressed ZuoraCreditorStepFunction executions are not useful
          | and no credit balance adjustments for negative invoices will take place
          |For general advice, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk
@@ -70,6 +70,6 @@ class Alarmer(publishToSNS: (String, String) => String) extends LazyLogging {
          |zuora-creditor repository: https://github.com/guardian/zuora-creditor
          |""".stripMargin
 
-    publishToSNS(messageBody, ReportDownloadFailureAlarmName)
+    publishToSNS(messageBody, reportDownloadFailureAlarmName)
   }
 }

--- a/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/AlarmerTest.scala
@@ -13,13 +13,13 @@ class AlarmerTest extends FlatSpec with Matchers {
   private val alarmer = Alarmer(publishToSNSMock)
 
   it should "send notification with correct alarm name or not if negInvoicesWithHolidayCreditAutomated > 0 " in {
-    alarmer.notifyIfAdjustmentTriggered(AdjustmentsReport(3, 2)) shouldEqual s"$AdjustmentExecutedAlarmName Alarm message-id: $TestMessageId"
+    alarmer.notifyIfAdjustmentTriggered(AdjustmentsReport(3, 2)) shouldEqual s"$adjustmentExecutedAlarmName Alarm message-id: $TestMessageId"
     alarmer.notifyIfAdjustmentTriggered(AdjustmentsReport(0, 0)) shouldEqual "not-published"
   }
 
   behavior of "notifyAboutReportDownloadFailure"
 
   it should  "send notification with correct alarm name for Report Download Failure" in {
-    alarmer.notifyAboutReportDownloadFailure("message") shouldEqual s"$ReportDownloadFailureAlarmName Alarm message-id: $TestMessageId"
+    alarmer.notifyAboutReportDownloadFailure("message") shouldEqual s"$reportDownloadFailureAlarmName Alarm message-id: $TestMessageId"
   }
 }


### PR DESCRIPTION
## What does this change?

As a prelude to a more complex change coming ( https://github.com/guardian/zuora-creditor/pull/186 ), rename few variables with a better casing
