### PR TITLE
Update build step with explicit manifest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,6 @@ libraryDependencies ++= Seq(
 )
 
 assembly / assemblyMergeStrategy := {
-  case PathList("META-INF", _*) => MergeStrategy.discard
-  case _                        => MergeStrategy.first
+  case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+  case _                                   => MergeStrategy.first
 }


### PR DESCRIPTION
## What does this change?

We update the build step with explicit manifest to solve an error thrown during initialisation. 

<img width="1142" alt="01 Screenshot 2023-02-08 at 22 24 25 (1)" src="https://user-images.githubusercontent.com/6035518/217761001-f6d7dc18-55cd-417e-ac1e-8481e205be48.png">

Thanks to user oripwk here: https://github.com/aws/aws-sdk-java-v2/issues/446