### PR TITLE
Stop using this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,7 @@
-# Zuora Creditor
+# !!This project has moved!!
+The new location is https://github.com/guardian/zuora-finance/tree/main/zuora-creditor
 
-This repository contains a Scala-based code API to handle the process of downloading a report of negative invoices from Zuora and transferring their balance into an account credit.
+Please don't make changes here.  The main branch will be locked.
 
-There is a concrete version of the ZuoraClients traint called `ZuoraClientsFromEnvironment.scala` which uses environment variables: `ZuoraApiAccessKeyId` `ZuoraApiSecretAccessKey` and `ZuoraApiHost`. 
-Simply set them in IntelliJ when testing locally, and never run locally with Production credentials.
- 
-The code is structured in a way that an implementing class only need to:
+The new repo is intended as a home for this and other projects that are subject to financial audit.
 
-- Configure the [Zuora Export command and filter criteria JSON](https://www.zuora.com/developer/api-reference/#operation/Object_POSTExport) for which negative invoices they want to target in a class which extends: `ExportCommand`
-- Configure how they want to generate a `CreditBalanceAdjustment` by extending the `CreateCreditBalanceAdjustmentCommand` trait which has a method which takes a single `NegativeInvoiceToTransfer` case class to start with.
-- Write your own main file or AWS Lambda function to orchestrate the stages of the process.
- 
-The repository contains the implementation of a specific use case of this process, which targets negative holiday suspension invoices. It has a main method for local testing and an AWS Lambda incorporated into the build system for deploying to production. See the Home Delivery Suspension Scala trait overrides: [src/main/resources/scala/com/gu/zuora/creditor/holidaysuspension/...](https://github.com/guardian/zuora-creditor/tree/main/src/main/scala/com/gu/zuora/creditor/holidaysuspension).
- 
-# Usage
-
-Run `sbt compile` to generate the SOAP client sources.
-Run `sbt assembly` to generate the Home Delivery Holiday Suspension AWS Lambda jar.

--- a/build.sbt
+++ b/build.sbt
@@ -1,54 +1,57 @@
-name := "zuora-creditor"
-description := "This project contains a set of services and Lambda functions which find negative invoices and converts " +
-  "them into a credit balance on the user's account, so that the amount is discounted off their next positive bill"
-version := "0.0.2"
-scalaVersion := "2.13.10"
-organization := "com.gu.zuora"
+// THIS REPO IS DEPRECATED.  Please see README.md
 
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-encoding",
-  "UTF-8",
-  "-feature",
-  "-language:existentials",
-  "-language:higherKinds",
-  "-language:implicitConversions",
-  "-unchecked",
-  "-Xfatal-warnings",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-Ywarn-value-discard"
-)
 
-lazy val root = (project in file(".")).enablePlugins(RiffRaffArtifact)
-
-assemblyJarName := "zuora-creditor.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Creditor"
-riffRaffArtifactResources += (file("cloudformation.yaml"), "cfn/cfn.yaml")
-
-addCommandAlias("dist", ";riffRaffArtifact")
-
-libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "software.amazon.awssdk" % "sns" % "2.17.225",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.7",
-  "com.typesafe.play" %% "play-json" % "2.9.4",
-  "ch.qos.logback" % "logback-classic" % "1.4.5",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "org.scalaj" %% "scalaj-http" % "2.4.2",
-  "io.kontainers" %% "purecsv" % "0.4.1",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.14.2",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.14.2",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.14.2",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.14.2",
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test
-)
-
-assembly / assemblyMergeStrategy := {
-  case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-  case _                                   => MergeStrategy.first
-}
+//name := "zuora-creditor"
+//description := "This project contains a set of services and Lambda functions which find negative invoices and converts " +
+//  "them into a credit balance on the user's account, so that the amount is discounted off their next positive bill"
+//version := "0.0.2"
+//scalaVersion := "2.13.10"
+//organization := "com.gu.zuora"
+//
+//scalacOptions ++= Seq(
+//  "-deprecation",
+//  "-encoding",
+//  "UTF-8",
+//  "-feature",
+//  "-language:existentials",
+//  "-language:higherKinds",
+//  "-language:implicitConversions",
+//  "-unchecked",
+//  "-Xfatal-warnings",
+//  "-Ywarn-dead-code",
+//  "-Ywarn-numeric-widen",
+//  "-Ywarn-value-discard"
+//)
+//
+//lazy val root = (project in file(".")).enablePlugins(RiffRaffArtifact)
+//
+//assemblyJarName := "zuora-creditor.jar"
+//riffRaffPackageType := assembly.value
+//riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+//riffRaffUploadManifestBucket := Option("riffraff-builds")
+//riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Creditor"
+//riffRaffArtifactResources += (file("cloudformation.yaml"), "cfn/cfn.yaml")
+//
+//addCommandAlias("dist", ";riffRaffArtifact")
+//
+//libraryDependencies ++= Seq(
+//  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+//  "software.amazon.awssdk" % "sns" % "2.17.225",
+//  "com.gu" %% "simple-configuration-ssm" % "1.5.7",
+//  "com.typesafe.play" %% "play-json" % "2.9.4",
+//  "ch.qos.logback" % "logback-classic" % "1.4.5",
+//  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+//  "org.scalaj" %% "scalaj-http" % "2.4.2",
+//  "io.kontainers" %% "purecsv" % "0.4.1",
+//  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.14.2",
+//  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.14.2",
+//  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
+//  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.14.2",
+//  "com.fasterxml.jackson.core" % "jackson-core" % "2.14.2",
+//  "org.scalatest" %% "scalatest" % "3.0.8" % Test
+//)
+//
+//assembly / assemblyMergeStrategy := {
+//  case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+//  case _                                   => MergeStrategy.first
+//}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds messages to say that the repo have moved to [`zuora-finance`](https://github.com/guardian/zuora-finance).

`README.md` has been replaced with a redirection message.
`build.sbt` has been commented out to prevent accidental build/deploy from here.

TeamCity has been reconfigured to build the project from the new location and the VCS Root for this repo has been removed.

Once merged, we should lock the main branch under branch protection rules to prevent further changes. 

NOTE: because we already reconfigured TeamCity, the PR is waiting indefinitely for the TC build to run, so going to override manually and merge.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
